### PR TITLE
Add multiple calls

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,0 +1,136 @@
+* rest.el
+
+** What is it?
+
+rest.el is an Emacs package with elisp functions to call REST API endpoints.
+It is meant as a ground for building elisp proxies to REST APIs, currently only
+by hand, but (hopefully) in the future by reading OpenAPI JSON API
+descriptions.
+
+** How to use it
+
+The functions use the [[https://melpa.org/#/request][request.el]] package to make the HTTP calls.  Most of the
+parameters used by the different functions have the same meaning in both
+packages.
+
+*** Calling a REST entry point
+
+The library provides functions to call the entry points, and some simple
+functions to render the results in buffers.  In this example, we call an entry
+point and render the result in a buffer as plain text (which is the default):
+
+#+NAME: Simple REST entry point call, showing results as RAW text.
+#+BEGIN_SRC emacs-lisp :results output none
+  (rest-call :type "GET"
+             :entrypoint "https://api.restful-api.dev/objects")
+#+END_SRC
+
+The previous call is non-blocking, so we can continue working with Emacs while
+it is processed.  The buffer with the results will appear when the answer is
+sent by the API, or a message will be displayed if an HTTP error is received.
+
+This is the same example, but rendering the results as JSON:
+
+#+NAME: Simple REST entry point call, showing JSON results.
+#+BEGIN_SRC emacs-lisp :results output none
+  (rest-call :type "GET"
+             :entrypoint "https://api.restful-api.dev/objects"
+             :success #'rest-json-to-buffer)
+#+END_SRC
+
+We can use our own functions to process the results.  In this example we
+provide to ~rest-call~ a customized function to process the returned JSON,
+showing a message with some information about the returned objects:
+
+#+NAME: Process the JSON returned from the API.
+#+BEGIN_SRC emacs-lisp :results output none
+  (rest-call :type "GET"
+             :entrypoint "https://api.restful-api.dev/objects"
+             :success
+             (cl-function
+              (lambda (&key
+                       data
+                       &allow-other-keys)
+                (let ((json (json-parse-string data :array-type 'list)))
+                  (message "%d items were returned. The last one was \"%s\"."
+                           (length json)
+                           (gethash "name" (car (reverse json))))))))
+#+END_SRC
+
+*** Parallel calls
+
+It is possible to execute several calls in parallel using the
+~rest-multiple-calls~ function:
+
+#+NAME: Parallel entry point calls.
+#+BEGIN_SRC emacs-lisp :results output none
+  (rest-multiple-calls
+   :parameters
+   '((:type "GET" :entrypoint "https://api.restful-api.dev/objects/1")
+     (:type "GET" :entrypoint "https://api.restful-api.dev/objects/2")))
+#+END_SRC
+
+As both entry points in the last example use the GET method, we could have used
+this simpler version to do the same.  In addition, we use the
+~rest-multiple-json-to-buffer~ function to format the output, opening a buffer
+for each JSON result provided by the API:
+
+#+NAME: Parallel calls sharing the same GET method and format results as JSON.
+#+BEGIN_SRC emacs-lisp :results output none
+  (rest-multiple-calls
+   :type "GET"
+   :success #'rest-multiple-json-to-buffer
+   :parameters
+   '((:entrypoint "https://api.restful-api.dev/objects/1")
+     (:entrypoint "https://api.restful-api.dev/objects/2")))
+#+END_SRC
+
+The ~rest-call~ function returns a list with most of the parameters used to
+call it in elisp.  When invoked with a non-nil ~dry-run~ parameter, it does not
+make the REST call.  This can be used to aggregate several calls to be executed
+in parallel with ~rest-multiple-calls~, as shown here:
+
+#+NAME: Parallel entry point calls with parameters used for single calls.
+#+BEGIN_SRC emacs-lisp :results output none
+  (rest-multiple-calls
+     :parameters
+     (list
+      (rest-call :dry-run t
+                 :type "GET"
+                 :entrypoint "https://api.restful-api.dev/objects/1")
+      (rest-call :dry-run t
+                 :type "GET"
+                 :entrypoint "https://api.restful-api.dev/objects/2")))
+#+END_SRC
+
+This is particularly useful for elisp API proxy functions:
+
+#+NAME: Make parallel calls of funcions using rest-api.
+#+BEGIN_SRC emacs-lisp :results output none
+  ;; We don't know which parameters this functions use with rest-call...
+  (cl-defun my-api-entrypoint1 (&key
+                                param1 param2 param3
+                                (dry-run nil))
+    (rest-call :type "GET"
+               :entrypoint (concat my-api-location "/entrypoint1")
+               :dry-run dry-run
+               :auth-header (...)
+               ...))
+
+  (cl-defun my-api-entrypoint2 (&key
+                                param1
+                                (dry-run nil))
+    (rest-call :type "GET"
+               :entrypoint (concat my-api-location "/entrypoint2")
+               :dry-run dry-run
+               :auth-header (...)
+               ...))
+
+  ;; ...but we can make those calls in parallel using :dry-run to get the
+  ;; parameters.
+  (rest-multiple-calls
+   :parameters
+   (list
+    (my-api-entrypoint1 :dry-run t :param1 1 :param2 2 :param3 3)
+    (my-api-entrypoint2 :dry-run t :param1 1)))
+#+END_SRC

--- a/README.org
+++ b/README.org
@@ -13,16 +13,16 @@ The functions use the [[https://melpa.org/#/request][request.el]] package to mak
 parameters used by the different functions have the same meaning in both
 packages.
 
-*** Calling a REST entry point
+*** Calling a REST endpoint
 
-The library provides functions to call the entry points, and some simple
-functions to render the results in buffers.  In this example, we call an entry
-point and render the result in a buffer as plain text (which is the default):
+The library provides functions to call the endpoints, and some simple functions
+to render the results in buffers.  In this example, we call an endpoint and
+render the result in a buffer as plain text (which is the default):
 
-#+NAME: Simple REST entry point call, showing results as RAW text.
+#+NAME: Simple REST endpoint call, showing results as RAW text.
 #+BEGIN_SRC emacs-lisp :results output none
   (rest-call :type "GET"
-             :entrypoint "https://api.restful-api.dev/objects")
+             :endpoint "https://api.restful-api.dev/objects")
 #+END_SRC
 
 The previous call is non-blocking, so we can continue working with Emacs while
@@ -31,10 +31,10 @@ sent by the API, or a message will be displayed if an HTTP error is received.
 
 This is the same example, but rendering the results as JSON:
 
-#+NAME: Simple REST entry point call, showing JSON results.
+#+NAME: Simple REST endpoint call, showing JSON results.
 #+BEGIN_SRC emacs-lisp :results output none
   (rest-call :type "GET"
-             :entrypoint "https://api.restful-api.dev/objects"
+             :endpoint "https://api.restful-api.dev/objects"
              :success #'rest-json-to-buffer)
 #+END_SRC
 
@@ -45,7 +45,7 @@ showing a message with some information about the returned objects:
 #+NAME: Process the JSON returned from the API.
 #+BEGIN_SRC emacs-lisp :results output none
   (rest-call :type "GET"
-             :entrypoint "https://api.restful-api.dev/objects"
+             :endpoint "https://api.restful-api.dev/objects"
              :success
              (cl-function
               (lambda (&key
@@ -62,15 +62,15 @@ showing a message with some information about the returned objects:
 It is possible to execute several calls in parallel using the
 ~rest-multiple-calls~ function:
 
-#+NAME: Parallel entry point calls.
+#+NAME: Parallel endpoint calls.
 #+BEGIN_SRC emacs-lisp :results output none
   (rest-multiple-calls
    :parameters
-   '((:type "GET" :entrypoint "https://api.restful-api.dev/objects/1")
-     (:type "GET" :entrypoint "https://api.restful-api.dev/objects/2")))
+   '((:type "GET" :endpoint "https://api.restful-api.dev/objects/1")
+     (:type "GET" :endpoint "https://api.restful-api.dev/objects/2")))
 #+END_SRC
 
-As both entry points in the last example use the GET method, we could have used
+As both endpoints in the last example use the GET method, we could have used
 this simpler version to do the same.  In addition, we use the
 ~rest-multiple-json-to-buffer~ function to format the output, opening a buffer
 for each JSON result provided by the API:
@@ -81,8 +81,8 @@ for each JSON result provided by the API:
    :type "GET"
    :success #'rest-multiple-json-to-buffer
    :parameters
-   '((:entrypoint "https://api.restful-api.dev/objects/1")
-     (:entrypoint "https://api.restful-api.dev/objects/2")))
+   '((:endpoint "https://api.restful-api.dev/objects/1")
+     (:endpoint "https://api.restful-api.dev/objects/2")))
 #+END_SRC
 
 The ~rest-call~ function returns a list with most of the parameters used to
@@ -90,17 +90,17 @@ call it in elisp.  When invoked with a non-nil ~dry-run~ parameter, it does not
 make the REST call.  This can be used to aggregate several calls to be executed
 in parallel with ~rest-multiple-calls~, as shown here:
 
-#+NAME: Parallel entry point calls with parameters used for single calls.
+#+NAME: Parallel endpoint calls with parameters used for single calls.
 #+BEGIN_SRC emacs-lisp :results output none
   (rest-multiple-calls
      :parameters
      (list
       (rest-call :dry-run t
                  :type "GET"
-                 :entrypoint "https://api.restful-api.dev/objects/1")
+                 :endpoint "https://api.restful-api.dev/objects/1")
       (rest-call :dry-run t
                  :type "GET"
-                 :entrypoint "https://api.restful-api.dev/objects/2")))
+                 :endpoint "https://api.restful-api.dev/objects/2")))
 #+END_SRC
 
 This is particularly useful for elisp API proxy functions:
@@ -108,20 +108,20 @@ This is particularly useful for elisp API proxy functions:
 #+NAME: Make parallel calls of funcions using rest-api.
 #+BEGIN_SRC emacs-lisp :results output none
   ;; We don't know which parameters this functions use with rest-call...
-  (cl-defun my-api-entrypoint1 (&key
-                                param1 param2 param3
-                                (dry-run nil))
+  (cl-defun my-api-endpoint1 (&key
+                              param1 param2 param3
+                              (dry-run nil))
     (rest-call :type "GET"
-               :entrypoint (concat my-api-location "/entrypoint1")
+               :endpoint (concat my-api-location "/endpoint1")
                :dry-run dry-run
                :auth-header (...)
                ...))
 
-  (cl-defun my-api-entrypoint2 (&key
-                                param1
-                                (dry-run nil))
+  (cl-defun my-api-endpoint2 (&key
+                              param1
+                              (dry-run nil))
     (rest-call :type "GET"
-               :entrypoint (concat my-api-location "/entrypoint2")
+               :endpoint (concat my-api-location "/endpoint2")
                :dry-run dry-run
                :auth-header (...)
                ...))
@@ -131,6 +131,6 @@ This is particularly useful for elisp API proxy functions:
   (rest-multiple-calls
    :parameters
    (list
-    (my-api-entrypoint1 :dry-run t :param1 1 :param2 2 :param3 3)
-    (my-api-entrypoint2 :dry-run t :param1 1)))
+    (my-api-endpoint1 :dry-run t :param1 1 :param2 2 :param3 3)
+    (my-api-endpoint2 :dry-run t :param1 1)))
 #+END_SRC

--- a/rest.el
+++ b/rest.el
@@ -163,6 +163,57 @@ formats it as JSON."
     (read-only-mode read-only-p)
     (pop-to-buffer (current-buffer))))
 
+(cl-defun rest-multiple-results-to-buffer (&key
+                                           results
+                                           format-buffer
+                                           buffer-name-pattern
+                                           (read-only-p t)
+                                           &allow-other-keys)
+  "Call FORMAT-BUFFER for all the entries in RESULTS.
+
+The BUFFER-NAME-PATTERN is a string which is used to format each buffer
+name.  It is used along with a counter for each of the entries in
+RESULTS."
+  (let ((count 1))
+    (dolist (elem results)
+      (funcall format-buffer
+               :data (cdr elem)
+               :read-only-p read-only-p
+               :buffer-name (format buffer-name-pattern count))
+      (cl-incf count))))
+
+(cl-defun rest-multiple-raw-to-buffer (&key
+                                       results
+                                       (buffer-name-pattern
+                                        "*raw-results-%03d*")
+                                       (read-only-p t)
+                                       &allow-other-keys)
+  "Call `rest-raw-to-buffer' for all the entries in RESULTS, using
+`rest-multiple-resuts-to-buffer'."
+  (rest-multiple-results-to-buffer :results results
+                                   :format-buffer #'rest-raw-to-buffer
+                                   :buffer-name-pattern buffer-name-pattern
+                                   :read-only-p read-only-p))
+
+(cl-defun rest-multiple-json-to-buffer (&key
+                                        results
+                                        (buffer-name-pattern
+                                         "*json-results-%03d*")
+                                        (read-only-p t)
+                                        &allow-other-keys)
+  "Call `rest-json-to-buffer' for all the entries in RESULTS, using
+`rest-multiple-resuts-to-buffer'."
+  (rest-multiple-results-to-buffer :results results
+                                   :format-buffer #'rest-json-to-buffer
+                                   :buffer-name-pattern buffer-name-pattern
+                                   :read-only-p read-only-p))
+
+(cl-defun rest-multiple-show-error (results
+                                    &allow-other-keys)
+  "Display an error message when a multiple call fails."
+  ;; TODO: provide useful information about the errors.
+  (message "Some of the multiple calls failed."))
+
 (cl-defun rest-show-error (&key
                            error-thrown
                            &allow-other-keys)

--- a/rest.el
+++ b/rest.el
@@ -81,6 +81,48 @@ calls with `rest-api-multiple-calls'."
         :success success
         :error error))
 
+(cl-defun rest-api-multiple-calls (&key
+                                   parameters
+                                   results
+                                   success
+                                   error
+                                   (type nil)
+                                   (accept nil)
+                                   (auth-header nil)
+                                   (data nil)
+                                   (content-type nil))
+  "Make parallel REST API calls using `rest-api-call' with the
+parameters stored in each of the entries of the PARAMETERS plist.
+Leave the results of individual calls in the RESULTS list, with
+entries being cons with the return code and the data.  Calls
+SUCCESS if all the calls are successful, or ERROR if any of them
+fails.
+
+Entries in the RESULTS list do not follow the same order as
+elements in the PARAMETERS plist.
+
+For each entry in the PARAMETERS plist, :entrypoint is required,
+and :sync, :success and :error are ignored.
+
+Any of the parameters TYPE, ACCEPT, AUTH-HEADER, DATA, and
+CONTENT-TYPE are used for entries in the PARAMETER list that
+don't specify them.
+
+Both SUCCESS and ERROR must expect the RESULTS list as parameter."
+  (dolist (entry parameters)
+    ;; TODO: complete this adding the callbacks functions.
+    (apply #'rest-api-call
+           (append
+            (:type (or type (plist-get entry :type)))
+            (:entrypoint (plist-get entry :entrypoint))
+            (:accept (or accept (plist-get entry :accept)))
+            (:auth-header (or auth-header (plist-get entry :auth-header)))
+            (:data (or data (plist-get entry :data)))
+            (:content-type (or content-type
+                               (plist-get entry :content-type)))
+            (:success #'rest-single-success)
+            (:error #'rest-single-error)))))
+
 (cl-defun rest-raw-to-buffer (&key
                               data
                               (buffer-name "*raw-results*")

--- a/rest.el
+++ b/rest.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2025 Coque Couto
 
 ;; Author: Coque Couto <coque.couto at gmail.com>
-;; Version: 0.1
+;; Version: 0.2
 ;; Package-Requires ((emacs "24.4") request json json-mode)
 ;; Keywords: comm lisp tools
 ;; URL: https://github.com/coquec/emacs-rest

--- a/rest.el
+++ b/rest.el
@@ -165,12 +165,12 @@ it, and formats it as JSON."
   "Generates a header to be used with `rest-api-call' for
 authenticated calls.
 
-KEY is a string with the API key or the JWT token.
+API-KEY is a string with the API key or the JWT token.
 
 TYPE may be \\='jwt for JWT authentication, which will produce an
-\\='Authentication: Bearer KEY\\=' header.
+\\='Authentication: Bearer API-KEY\\=' header.
 
-Any other TYPE will produce an \\='apikey: KEY\\=' header."
+Any other TYPE will produce an \\='apikey: API-KEY\\=' header."
   (cond ((eq type 'jwt)
          `("Authorization" . ,(concat "Bearer " api-key)))
         (t

--- a/rest.el
+++ b/rest.el
@@ -138,8 +138,8 @@ Both SUCCESS and ERROR must expect the RESULTS list as parameter."
                               (buffer-name "*raw-results*")
                               (read-only-p t)
                               &allow-other-keys)
-  "Deletes the contents of the buffer BUFFER-NAME, paste DATA into
-it, and leaves it unformatted."
+  "Deletes the contents of the buffer BUFFER-NAME, paste DATA into it, and
+leaves it unformatted."
   (with-current-buffer (get-buffer-create buffer-name)
     (read-only-mode -1)
     (erase-buffer)
@@ -152,8 +152,8 @@ it, and leaves it unformatted."
                                (buffer-name "*json-results*")
                                (read-only-p t)
                                &allow-other-keys)
-  "Deletes the contents of the buffer BUFFER-NAME, paste DATA into
-it, and formats it as JSON."
+  "Deletes the contents of the buffer BUFFER-NAME, paste DATA into it, and
+formats it as JSON."
   (with-current-buffer (get-buffer-create buffer-name)
     (read-only-mode -1)
     (erase-buffer)
@@ -166,14 +166,13 @@ it, and formats it as JSON."
 (cl-defun rest-show-error (&key
                            error-thrown
                            &allow-other-keys)
-  "Writes a message with the ERROR-THROWN."
+  "Write a message with the ERROR-THROWN."
   (message "Error: %S" error-thrown))
 
 (cl-defun rest-auth-header (&key
                             api-key
                             (type nil))
-  "Generates a header to be used with `rest-api-call' for
-authenticated calls.
+  "Generate a header to be used with `rest-call' for authenticated calls.
 
 API-KEY is a string with the API key or the JWT token.
 

--- a/rest.el
+++ b/rest.el
@@ -36,7 +36,7 @@
 (cl-defun rest-api-call (&key
                          type
                          entrypoint
-                         (mock nil)
+                         (dry-run nil)
                          (sync nil)
                          (timeout nil)
                          (accept "application/vnd.api+json")
@@ -45,18 +45,16 @@
                          (content-type nil)
                          (success #'rest-raw-to-buffer)
                          (error #'rest-show-error))
-  "When the MOCK parameter is nil, make a REST API call of type TYPE
-to the ENTRYPOINT URL, including ACCEPT, AUTH-HEADER, and
-CONTENT-TYPE as headers.  SUCCESS is called with the resulting
-data.
+  "When the DRY-RUN parameter is nil, make a REST API call of type TYPE to
+the ENTRYPOINT URL, including ACCEPT, AUTH-HEADER, and CONTENT-TYPE as
+headers.  SUCCESS is called with the resulting data.
 
-The other parameters work as described in the `request'
-documentation.
+The other parameters work as described in the `request' documentation.
 
-Return a list of the parameters used to call it.  Used along a
-non-nil MOCK, these return values can be used to make parallel
-calls with `rest-api-multiple-calls'."
-  (unless mock
+Return a list of the parameters used to call it.  Used along a non-nil
+DRY-RUN, these return values can be used to make parallel calls with
+`rest-api-multiple-calls'."
+  (unless dry-run
     (request
       entrypoint
       :sync sync
@@ -73,7 +71,7 @@ calls with `rest-api-multiple-calls'."
       :error error))
   (list :type type
         :entrypoint entrypoint
-        :mock mock
+        :dry-run dry-run
         :sync sync
         :accept accept
         :auth-header auth-header
@@ -92,21 +90,20 @@ calls with `rest-api-multiple-calls'."
                                    (auth-header nil)
                                    (data nil)
                                    (content-type nil))
-  "Make parallel REST API calls using `rest-api-call' with the
-parameters stored in each of the entries of the PARAMETERS plist.
-Leave the results of individual calls in the RESULTS list, with
-entries being cons with (SYMBOL-STATUS . DATA).  Calls SUCCESS if
-all the calls are successful, or ERROR if any of them fails.
+  "Make parallel REST API calls using `rest-api-call' with the parameters
+stored in each of the entries of the PARAMETERS plist.  Leave the
+results of individual calls in the RESULTS list, with entries being cons
+with (SYMBOL-STATUS . DATA).  Calls SUCCESS if all the calls are
+successful, or ERROR if any of them fails.
 
-Entries in the RESULTS list do not follow the same order as
-elements in the PARAMETERS plist.
+Entries in the RESULTS list do not follow the same order as elements in
+the PARAMETERS plist.
 
-For each entry in the PARAMETERS plist, :entrypoint is required,
-and :sync, :success and :error are ignored.
+For each entry in the PARAMETERS plist, :entrypoint is required, and
+:sync, :success and :error are ignored.
 
-Any of the parameters TYPE, ACCEPT, AUTH-HEADER, DATA, and
-CONTENT-TYPE are used for entries in the PARAMETER list that
-don't specify them.
+Any of the parameters TYPE, ACCEPT, AUTH-HEADER, DATA, and CONTENT-TYPE
+are used for entries in the PARAMETER list that don't specify them.
 
 Both SUCCESS and ERROR must expect the RESULTS list as parameter."
   (let ((counter (length parameters))

--- a/rest.el
+++ b/rest.el
@@ -38,6 +38,7 @@
                          entrypoint
                          (mock nil)
                          (sync nil)
+                         (timeout nil)
                          (accept "application/vnd.api+json")
                          (auth-header nil)
                          (data nil)
@@ -59,7 +60,7 @@ calls with `rest-api-multiple-calls'."
     (request
       entrypoint
       :sync sync
-      :timeout (when sync 3)
+      :timeout timeout
       :type type
       :headers
       (append `(("accept" . ,accept))

--- a/rest.el
+++ b/rest.el
@@ -33,35 +33,53 @@
 (require 'json)
 (require 'json-mode)
 
-(cl-defun rest-api-call (type
+(cl-defun rest-api-call (&key
+                         type
                          entrypoint
-                         &key
+                         (mock nil)
                          (sync nil)
                          (accept "application/vnd.api+json")
                          (auth-header nil)
                          (data nil)
                          (content-type nil)
                          (success #'rest-raw-to-buffer)
-                         (error #'rest-show-error)
-                         &allow-other-keys)
-  "Make a REST API call of type TYPE to the ENTRYPOINT URL,
-including ACCEPT, AUTH-HEADER, and CONTENT-TYPE as headers.
-Calls SUCCESS with the resulting data.  The rest of parameters
-work as described in the `request' documentation."
-  (request
-    entrypoint
-    :sync sync
-    :timeout (when sync 3)
-    :type type
-    :headers
-    (append `(("accept" . ,accept))
-            (and auth-header
-                 (list auth-header))
-            (and content-type
-                 `(("Content-Type" . ,content-type))))
-    :data data
-    :success success
-    :error error))
+                         (error #'rest-show-error))
+  "When the MOCK parameter is nil, make a REST API call of type TYPE
+to the ENTRYPOINT URL, including ACCEPT, AUTH-HEADER, and
+CONTENT-TYPE as headers.  SUCCESS is called with the resulting
+data.
+
+The other parameters work as described in the `request'
+documentation.
+
+Return a list of the parameters used to call it.  Used along a
+non-nil MOCK, these return values can be used to make parallel
+calls with `rest-api-multiple-calls'."
+  (unless mock
+    (request
+      entrypoint
+      :sync sync
+      :timeout (when sync 3)
+      :type type
+      :headers
+      (append `(("accept" . ,accept))
+              (and auth-header
+                   (list auth-header))
+              (and content-type
+                   `(("Content-Type" . ,content-type))))
+      :data data
+      :success success
+      :error error))
+  (list :type type
+        :entrypoint entrypoint
+        :mock mock
+        :sync sync
+        :accept accept
+        :auth-header auth-header
+        :data data
+        :content-type content-type
+        :success success
+        :error error))
 
 (cl-defun rest-raw-to-buffer (&key
                               data

--- a/rest.el
+++ b/rest.el
@@ -33,27 +33,29 @@
 (require 'json)
 (require 'json-mode)
 
-(cl-defun rest-api-call (&key
-                         type
-                         entrypoint
-                         (dry-run nil)
-                         (sync nil)
-                         (timeout nil)
-                         (accept "application/vnd.api+json")
-                         (auth-header nil)
-                         (data nil)
-                         (content-type nil)
-                         (success #'rest-raw-to-buffer)
-                         (error #'rest-show-error))
+(cl-defun rest-call (&key
+                     type
+                     entrypoint
+                     (dry-run nil)
+                     (sync nil)
+                     (timeout nil)
+                     (accept "application/vnd.api+json")
+                     (auth-header nil)
+                     (data nil)
+                     (content-type nil)
+                     (success #'rest-raw-to-buffer)
+                     (error #'rest-show-error)
+                     (complete nil))
   "When the DRY-RUN parameter is nil, make a REST API call of type TYPE to
 the ENTRYPOINT URL, including ACCEPT, AUTH-HEADER, and CONTENT-TYPE as
 headers.  SUCCESS is called with the resulting data.
 
 The other parameters work as described in the `request' documentation.
 
-Return a list of the parameters used to call it.  Used along a non-nil
-DRY-RUN, these return values can be used to make parallel calls with
-`rest-api-multiple-calls'."
+Return a list of the parameters used to call it, except DRY-RUN, SYNC,
+SUCCESS, ERROR, and COMPLETE.  Used along a non-nil DRY-RUN, these
+return values can be used to make parallel calls with
+`rest-multiple-calls'."
   (unless dry-run
     (request
       entrypoint
@@ -68,18 +70,14 @@ DRY-RUN, these return values can be used to make parallel calls with
                    `(("Content-Type" . ,content-type))))
       :data data
       :success success
-      :error error))
+      :error error
+      :complete complete))
   (list :type type
         :entrypoint entrypoint
-        :dry-run dry-run
-        :sync sync
+        :timeout timeout
         :accept accept
-        :auth-header auth-header
+        :auth auth-header
         :data data
-        :content-type content-type
-        :success success
-        :error error))
-
 (cl-defun rest-api-multiple-calls (&key
                                    parameters
                                    results

--- a/rest.el
+++ b/rest.el
@@ -35,7 +35,7 @@
 
 (cl-defun rest-call (&key
                      type
-                     entrypoint
+                     endpoint
                      (dry-run nil)
                      (sync nil)
                      (timeout nil)
@@ -47,7 +47,7 @@
                      (error #'rest-show-error)
                      (complete nil))
   "When the DRY-RUN parameter is nil, make a REST API call of type TYPE to
-the ENTRYPOINT URL, including ACCEPT, AUTH-HEADER, and CONTENT-TYPE as
+the ENDPOINT URL, including ACCEPT, AUTH-HEADER, and CONTENT-TYPE as
 headers.  SUCCESS is called with the resulting data.
 
 The other parameters work as described in the `request' documentation.
@@ -58,7 +58,7 @@ return values can be used to make parallel calls with
 `rest-multiple-calls'."
   (unless dry-run
     (request
-      entrypoint
+      endpoint
       :sync sync
       :timeout timeout
       :type type
@@ -73,7 +73,7 @@ return values can be used to make parallel calls with
       :error error
       :complete complete))
   (list :type type
-        :entrypoint entrypoint
+        :endpoint endpoint
         :timeout timeout
         :accept accept
         :auth auth-header
@@ -98,7 +98,7 @@ the calls are successful, or to ERROR if any of them fails.  Entries in
 this list do not follow the same order as elements in the PARAMETERS
 plist.
 
-For each element in the PARAMETERS plist, :entrypoint is required, and
+For each element in the PARAMETERS plist, :endpoint is required, and
 :sync, :success and :error are ignored.
 
 Any of the parameters TYPE, ACCEPT, AUTH-HEADER, DATA, and CONTENT-TYPE
@@ -113,16 +113,16 @@ Return a list with the lists of parameters used to call `rest-call'."
         (api-results nil)
         (result nil))
     (dolist (entry parameters)
-      (let* ((type (or type (plist-get entry :type)))
-             (entrypoint (plist-get entry :entrypoint))
+      (let* ((type (rest--param :type type entry))
+             (endpoint (plist-get entry :endpoint))
              ;; Make a first dry-run call to get the default parameters.
              (defaults (rest-call :dry-run t
                                   :type type
-                                  :entrypoint entrypoint)))
+                                  :endpoint endpoint)))
         (push
          (rest-call
           :type type
-          :entrypoint entrypoint
+          :endpoint endpoint
           :accept (rest--param :accept accept entry defaults)
           :auth-header (rest--param :auth-header auth-header entry defaults)
           :data (rest--param :data data entry defaults)


### PR DESCRIPTION
New version 0.2 with some changes in the interfaces.

* Add README.org.
* Rename `rest-api-call` to `rest-call`.
* Rename `entrypoint` parameters to `endpoint`.
* Add the `complete` parameter to `rest-call`.
* Make `type` and `endpoint` named parameters.
* Add functions to allow multiple parallel calls to endpoints.
* Add the `dry-run` parameter to make it easy to make multiple calls from code that doesn't know the parameters to use.